### PR TITLE
Add back binder icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # Biochemical Engineering (CBI 310)
 
-### Chapter 1
+## Chapter 1
 
 * [Introduction and bio basics](https://nbviewer.jupyter.org/github/willienicol/Biochemical-engineering-notes/blob/master/Introduction%20and%20bio%20background/Intro%20and%20bio%20background.ipynb)
 
-### Chapter 2
+## Chapter 2
 
 * [Basic biochemistry](https://nbviewer.jupyter.org/github/willienicol/Biochemical-engineering-notes/blob/master/2%20Basic%20biochemistry/Basic%20Biochemistry.ipynb) 
 
-### Chapter 3
+## Chapter 3
 
 * [3.1 Defining rates and yields and balancing equations](https://nbviewer.jupyter.org/github/willienicol/Biochemical-engineering-notes/blob/master/3%20Stoichiometry%20without%20internal%20reactions/Defining%20rates%20and%20yields%20and%20balancing%20equations.ipynb)
 
@@ -17,15 +17,18 @@
 * [3.3 Degree of reduction balances](https://nbviewer.jupyter.org/github/willienicol/Biochemical-engineering-notes/blob/master/3%20Stoichiometry%20without%20internal%20reactions/Degree%20of%20reduction%20balances.ipynb)
 
 
-### Chapter 4
+## Chapter 4
 
 * [4.1 Modelling the anabolism](https://nbviewer.jupyter.org/github/willienicol/Biochemical-engineering-notes/blob/master/4%20Stoichiometry%20that%20includes%20internal%20reactions/Modelling%20the%20anabolism.ipynb)
 
-### Tutorials
+## Tutorials
 
 * [Getting started with Jupyter Notebooks](https://nbviewer.jupyter.org/github/willienicol/Biochemical-engineering-notes/blob/master/Tutorials/Getting%20started%20with%20Jupyter%20Notebooks.ipynb)
 
 * [Tutorial 0](https://nbviewer.jupyter.org/github/willienicol/Biochemical-engineering-notes/blob/master/Tutorials/Tut%200.ipynb)
 
+## Binder
 
+You can run the python code remotely by using the binder. This will be much slower than running the notebook server on your computer.
 
+[![Binder](http://mybinder.org/badge.svg)](http://mybinder.org/repo/willienicol/Biochemical-engineering-notes)


### PR DESCRIPTION
Now that the `environment.yml` has been pulled, we can add back the binder icon - it works again.